### PR TITLE
Make event search examples match

### DIFF
--- a/api/events.rst
+++ b/api/events.rst
@@ -71,7 +71,7 @@ This method also allows specifying an alternate output format, by
 specifying ``format=rss`` or ``format=ics``.
 
 **Example:**
-:ref:`openstates.org/api/v1/events/?state=ca <event-search-example>`
+:ref:`openstates.org/api/v1/events/?state=tx <event-search-example>`
 
 .. _event-detail:
 


### PR DESCRIPTION
Example link had `state=ca` but the example data is actually `state=tx`
This is particularly confusing, since events are not currently supported for `ca`.